### PR TITLE
fix: add static keyword to LButton

### DIFF
--- a/src/include/ui/LButton.h
+++ b/src/include/ui/LButton.h
@@ -5,8 +5,8 @@
 class LButton {
 public:
 	//Button dimensions
-	int kButtonWidth;
-	int kButtonHeight;
+	static const int kButtonWidth = 200;
+	static const int kButtonHeight = 100;
 
 	//Initializes internal variables
 	LButton();


### PR DESCRIPTION
### 🛠 Proposed Changes:

This PR fixes an issue regarding the `static` property of the LButton's width and height.