### PR TITLE
fix: justified the stats in endscreen UI, made text slightly larger.

### DIFF
--- a/src/include/states/EndScreenState.h
+++ b/src/include/states/EndScreenState.h
@@ -18,8 +18,8 @@ public:
     static const int STAT_COUNT = 4; /** @brief Number of statistics in the main menu. */
 
     static constexpr float END_SCREEN_BUTTON_HEIGHT = 40.0f; /** @brief height of a button. */
-    static constexpr float END_SCREEN_STATS_HEIGHT = 10.0f; /** @brief height of stats. */
-    static constexpr float END_SCREEN_STATS_WIDTH = 60.0f; /** @brief width of stats. */
+    static constexpr float END_SCREEN_STATS_HEIGHT = 13.0f; /** @brief height of stats. */
+    static constexpr float END_SCREEN_STATS_SPACING = 7.0f; /** @brief spacing of stats. */
     static constexpr float END_SCREEN_UI_SPACING = 20.0f; /** @brief spacing for UI elements. */
     static constexpr float END_SCREEN_TITLE_WIDTH = 350.0f; /** @brief width of title on endscreen. */
     const static std::string DEFAULT_KILLER_CRITTER_STR; /** @brief default critter type for when you win the game. */

--- a/src/include/states/GameOverState.h
+++ b/src/include/states/GameOverState.h
@@ -16,6 +16,7 @@ public:
     const static std::string TANK_CRITTER_TYPE;
     const static std::string NORMAL_CRITTER_TYPE;
     const static int CRITTER_ANIMATION_WIDTH = 320;  /** @brief width of critter animation on endscreen. */
+    const static int CRITTER_ANIMATION_X_POSITION = 0;  /** @brief x position of critter animation on endscreen. */
 
     //Transitions
     bool enter() override;

--- a/src/states/EndScreenState.cpp
+++ b/src/states/EndScreenState.cpp
@@ -193,9 +193,8 @@ void EndScreenState::render() {
 		buttons[i].render();
 	}
 
-
-	float statsHeight = (1.0f / 2.0f) * Global::kScreenHeight;
-
+	float statsHeight = (4.0f / 9.0f) * Global::kScreenHeight;
+	float buttonWidth = EndScreenState::END_SCREEN_BUTTON_HEIGHT * buttons[0].kButtonWidth / buttons[0].kButtonHeight;
 
 	for (int i = 0; i < STAT_COUNT; ++i) {
 		if (i == 0 && !killedBy.compare(EndScreenState::DEFAULT_KILLER_CRITTER_STR))
@@ -203,14 +202,19 @@ void EndScreenState::render() {
 			continue;
 		}
 
+		//float labelWidth = EndScreenState::END_SCREEN_STATS_HEIGHT * statLabels[i].getWidth() / statLabels[i].getHeight();
+		float labelWidth = EndScreenState::END_SCREEN_STATS_HEIGHT * stats[i].getWidth() / stats[i].getHeight();
+
 		statLabels[i].render(
-			Global::kScreenWidth / 2.0f - EndScreenState::END_SCREEN_STATS_WIDTH, 
-			statsHeight, 
-			nullptr, 
+			//(Global::kScreenWidth) / 2.0f - labelWidth,
+			(Global::kScreenWidth - buttonWidth) / 2.0f,
+			statsHeight,
+			nullptr,
 			0, EndScreenState::END_SCREEN_STATS_HEIGHT);
-		
+
 		stats[i].render(
-			Global::kScreenWidth / 2.0f + EndScreenState::END_SCREEN_STATS_WIDTH,
+			//Global::kScreenWidth / 2.0f + EndScreenState::END_SCREEN_STATS_SPACING,
+			(Global::kScreenWidth + buttonWidth) / 2.0f - labelWidth,
 			statsHeight,
 			nullptr,
 			0, EndScreenState::END_SCREEN_STATS_HEIGHT);

--- a/src/states/GameOverState.cpp
+++ b/src/states/GameOverState.cpp
@@ -84,7 +84,7 @@ void GameOverState::render() {
 	
 	float critterAnimationHeight = (1.0f / 15.0f) * Global::kScreenHeight;
 	
-	textureWalkDown.render((Global::kScreenWidth - CRITTER_ANIMATION_WIDTH) / 2.0f, critterAnimationHeight, clip, CRITTER_ANIMATION_WIDTH, CRITTER_ANIMATION_WIDTH);
+	textureWalkDown.render((Global::kScreenWidth - CRITTER_ANIMATION_WIDTH) / 2.0f, CRITTER_ANIMATION_X_POSITION, clip, CRITTER_ANIMATION_WIDTH, CRITTER_ANIMATION_WIDTH);
 }
 
 /**


### PR DESCRIPTION
### 🛠 Proposed Changes:

Modifications to UI screen for endscreens.

### 📝 Details:

- Stat labels were pushed to the left, aligning with buttons
- Stats were pushed to the right, aligning with buttons
- Moved Critter animation slightly higher

![image](https://github.com/user-attachments/assets/f570236b-e310-4ef2-96f9-8fb8e27b994f)

### 🔗 Related Issue(s):

- Resolves #60 